### PR TITLE
Retain prior selection after component is updated.

### DIFF
--- a/src/core/helpers/dom.helper.js
+++ b/src/core/helpers/dom.helper.js
@@ -4,6 +4,21 @@ export const getDroptargets = (el, dropzoneSelector) =>
 export const getDraggables = (el, draggableSelector) =>
   el.querySelectorAll(draggableSelector);
 
+export const updateInitialAttributes = function (el) {
+  this.targets = getDroptargets(el, this.defaultOptions.dropzoneSelector);
+  this.items = getDraggables(el, this.defaultOptions.draggableSelector);
+  for (let i = 0; i < this.targets.length; i++) {
+    this.targets[i].setAttribute('aria-dropeffect', 'none');
+  }
+
+  for (let i = 0; i < this.items.length; i++) {
+    this.items[i].setAttribute('draggable', 'true');
+    if (this.items[i].getAttribute('aria-grabbed') !== 'true') {
+      this.items[i].setAttribute('aria-grabbed', 'false');
+    }
+    this.items[i].setAttribute('tabindex', '0');
+  }
+};
 export const setInitialAtributes = function (el) {
   this.targets = getDroptargets(el, this.defaultOptions.dropzoneSelector);
   this.items = getDraggables(el, this.defaultOptions.draggableSelector);

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,5 +1,5 @@
 import { attachListeners } from './listeners';
-import { setInitialAtributes } from './helpers';
+import { setInitialAtributes, updateInitialAttributes } from './helpers';
 import { getOptions } from './options';
 import { getState } from './state';
 
@@ -24,5 +24,9 @@ export class VueDraggable {
 
   initiate(el) {
     setInitialAtributes.bind(this)(el);
+  }
+
+  update(el) {
+    updateInitialAttributes.bind(this)(el);
   }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ export const VueDraggableDirective = {
     setTimeout(() => {
       instances.forEach(instance => {
         if (instance.el !== el) return;
-        instance.initiate(el);
+        instance.update(el);
       });
     });
   },


### PR DESCRIPTION
This will solve an issue when items are dynamically added to the list after a timeout/ajax call, the component update was de-selecting the prior selected items.